### PR TITLE
Removes URL trailing slashes

### DIFF
--- a/src/lib/util.rs
+++ b/src/lib/util.rs
@@ -35,12 +35,13 @@ pub fn to_object_id(id: String) -> Result<ObjectId, Error> {
 }
 
 pub fn parse_url(url: &str) -> Result<url::Url, Error> {
-  let mut url = url::Url::parse(url).map_err(|_| Error::ParseURL())?;
+  let mut url = url.to_owned();
+  // Removes the URL trailing slashes
+  while url.ends_with('/') {
+    url.pop();
+  }
 
-  url
-    .path_segments_mut()
-    .map_err(|_| Error::ParseURL())?
-    .pop_if_empty();
+  let url = url::Url::parse(url.as_str()).map_err(|_| Error::ParseURL())?;
 
   Ok(url)
 }


### PR DESCRIPTION
This change will help to find duplicate resources even if the URL contains multiple trailing slashes.