### PR TITLE
Implement user metric endpoint

### DIFF
--- a/src/routes/resource.rs
+++ b/src/routes/resource.rs
@@ -105,7 +105,7 @@ async fn get_resource_by_id(ctx: Ctx, id: ID, user_id: UserID) -> Response {
 }
 
 async fn query_resources(ctx: Ctx, user_id: UserID, qs: web::Query<Query>) -> Response {
-  let sort_option = qs.sort.clone().unwrap_or("position_asc".into());
+  let sort_option = qs.sort.clone().unwrap_or_else(|| "position_asc".into());
   let mut query = doc! { "user": user_id.0 };
 
   let sort = match sort_option.as_str() {
@@ -149,10 +149,14 @@ async fn query_resources(ctx: Ctx, user_id: UserID, qs: web::Query<Query>) -> Re
 }
 
 async fn create_resource(ctx: Ctx, body: ResourceCreateBody, user_id: UserID) -> Response {
-  let list_id = to_object_id(body.list.clone().into())?;
+  let list_id = to_object_id(body.list.clone())?;
   let user_id = user_id.0;
   let url = util::parse_url(body.url.clone().as_str())?;
-  let tags = body.tags.clone().map(util::sanitize_tags).unwrap_or(vec![]);
+  let tags = body
+    .tags
+    .clone()
+    .map(util::sanitize_tags)
+    .unwrap_or_default();
 
   let last_resource = Resource::find_last(&ctx.database.conn, &user_id, &list_id).await?;
 

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -1,15 +1,17 @@
 use actix_web::{web, HttpResponse};
 use actix_web_httpauth::middleware::HttpAuthentication;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use validator::Validate;
 use wither::bson::doc;
+use wither::bson::Bson;
 use wither::Model;
 
 use crate::auth;
 use crate::lib::create_demo_data_for_user;
 use crate::lib::date;
 use crate::lib::token;
+use crate::models::resource::Resource;
 use crate::models::user;
 use crate::models::user::PrivateUser;
 use crate::models::user::User;
@@ -58,6 +60,11 @@ pub fn create_router(cfg: &mut web::ServiceConfig) {
   cfg.service(
     web::resource("/users/me")
       .route(web::get().to(get_session))
+      .wrap(auth.clone()),
+  );
+  cfg.service(
+    web::resource("/users/me/metrics")
+      .route(web::get().to(get_metrics))
       .wrap(auth.clone()),
   );
   cfg.service(web::resource("/users/verification/{token}").route(web::get().to(verify_user_email)));
@@ -131,6 +138,37 @@ async fn get_session(ctx: Ctx, user: UserID) -> Response {
 
   debug!("Returning user");
   let res = HttpResponse::Ok().json(user);
+  Ok(res)
+}
+
+async fn get_metrics(ctx: Ctx, user: UserID) -> Response {
+  let user_id = user.0;
+  let pipeline = vec![
+    doc! {
+      "$match": {
+        "user": user_id,
+        "completed_at": { "$exists": true, "$ne": Bson::Null }
+      }
+    },
+    doc! {
+      "$group": {
+        "_id": {
+          "$dateToString": {
+            "date":   "$completed_at",
+            "format": "%Y-%m-%d",
+            // TODO: Send and probably store the user timezone from the front-end
+            // timezone: timezone
+          }
+        },
+        "completed_count": { "$sum": 1 }
+      }
+    },
+  ];
+
+  let metrics = ctx.models.aggregate::<Resource, Metric>(pipeline).await?;
+
+  debug!("Returning user metrics");
+  let res = HttpResponse::Ok().json(metrics);
   Ok(res)
 }
 
@@ -392,4 +430,11 @@ async fn find_user_by_slug(ctx: web::Data<Context>, slug: web::Path<String>) -> 
   debug!("Returning public user");
   let res = HttpResponse::Ok().json(user);
   Ok(res)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Metric {
+  #[serde(alias = "_id")]
+  date: String,
+  completed_count: i64,
 }

--- a/src/routes/webhooks/rss.rs
+++ b/src/routes/webhooks/rss.rs
@@ -20,7 +20,7 @@ pub fn create_router(cfg: &mut web::ServiceConfig) {
 async fn webhook(ctx: web::Data<Context>, body: WebhookBody) -> Response {
   debug!("Processing RSS webhook from rssapi");
 
-  if body.new_entries.len() == 0 {
+  if body.new_entries.is_empty() {
     debug!("RSS webhook does not contain new entries, returning 400 status code");
     return Ok(HttpResponse::BadRequest().finish());
   }


### PR DESCRIPTION
This PR adds the new `/users/me/metrics` endpoint with the following response:

```json
[
    {
        "date": "2021-04-04",
        "completed_count": 1
    },
    {
        "date": "2021-02-22",
        "completed_count": 8
    },
   ...
]
```